### PR TITLE
fix: use function-environment-configs for dns-config

### DIFF
--- a/composition-direct.yaml
+++ b/composition-direct.yaml
@@ -16,7 +16,20 @@ spec:
   mode: Pipeline
   pipeline:
   
-  # Step 1: Generate resources using go-templating with environment data
+  # Step 1: Load environment configuration
+  - step: load-environment
+    functionRef:
+      name: function-environment-configs
+    input:
+      apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+      kind: Input
+      spec:
+        environmentConfigs:
+        - type: Reference
+          ref:
+            name: dns-config  # Global DNS config with zone
+  
+  # Step 2: Generate resources using go-templating with environment data
   - step: deploy-app
     functionRef:
       name: function-go-templating
@@ -31,8 +44,12 @@ spec:
           {{- $xrName := .observed.composite.resource.metadata.name }}
           {{- $appName := .observed.composite.resource.spec.name | default "whoami" }}
           
-          {{/* For now, default to localhost - dns-config integration needs different approach */}}
+          {{/* Determine domain from dns-config or default to localhost */}}
           {{- $domain := printf "%s.localhost" $appName }}
+          {{- $zone := index .context "apiextensions.crossplane.io/environment" "zone" }}
+          {{- if $zone }}
+            {{- $domain = printf "%s.%s" $appName $zone }}
+          {{- end }}
           
           ---
           # Namespace
@@ -188,7 +205,7 @@ spec:
           status:
             domain: {{ $domain }}
   
-  # Step 2: Mark as ready when all resources are created
+  # Step 3: Mark as ready when all resources are created
   - step: auto-ready
     functionRef:
       name: function-auto-ready

--- a/composition-direct.yaml
+++ b/composition-direct.yaml
@@ -13,13 +13,6 @@ spec:
     apiVersion: demo.openportal.dev/v1alpha1
     kind: WhoAmIApp
   
-  # Load the global DNS config
-  environment:
-    environmentConfigs:
-    - type: Reference
-      ref:
-        name: dns-config  # Global DNS config with zone
-  
   mode: Pipeline
   pipeline:
   
@@ -38,13 +31,8 @@ spec:
           {{- $xrName := .observed.composite.resource.metadata.name }}
           {{- $appName := .observed.composite.resource.spec.name | default "whoami" }}
           
-          {{/* Determine domain from dns-config or default to localhost */}}
+          {{/* For now, default to localhost - dns-config integration needs different approach */}}
           {{- $domain := printf "%s.localhost" $appName }}
-          {{- if .context.environment }}
-            {{- if .context.environment.zone }}
-              {{- $domain = printf "%s.%s" $appName .context.environment.zone }}
-            {{- end }}
-          {{- end }}
           
           ---
           # Namespace

--- a/composition-gitops.yaml
+++ b/composition-gitops.yaml
@@ -13,13 +13,6 @@ spec:
     apiVersion: demo.openportal.dev/v1alpha1
     kind: WhoAmIApp
   
-  # Load the global DNS config
-  environment:
-    environmentConfigs:
-    - type: Reference
-      ref:
-        name: dns-config  # Global DNS config with zone
-  
   mode: Pipeline
   pipeline:
   
@@ -39,13 +32,8 @@ spec:
           {{- $appName := .observed.composite.resource.spec.name | default "whoami" }}
           {{- $namespace := .observed.composite.resource.metadata.namespace }}
           
-          {{/* Determine domain from dns-config or default to localhost */}}
+          {{/* For now, default to localhost - dns-config integration needs different approach */}}
           {{- $domain := printf "%s.localhost" $appName }}
-          {{- if .context.environment }}
-            {{- if .context.environment.zone }}
-              {{- $domain = printf "%s.%s" $appName .context.environment.zone }}
-            {{- end }}
-          {{- end }}
           
           {{/* Generate the deployment manifest content */}}
           {{- $deploymentYaml := printf `---

--- a/composition-gitops.yaml
+++ b/composition-gitops.yaml
@@ -16,7 +16,20 @@ spec:
   mode: Pipeline
   pipeline:
   
-  # Step 1: Generate GitOps resources using go-templating
+  # Step 1: Load environment configuration
+  - step: load-environment
+    functionRef:
+      name: function-environment-configs
+    input:
+      apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+      kind: Input
+      spec:
+        environmentConfigs:
+        - type: Reference
+          ref:
+            name: dns-config  # Global DNS config with zone
+  
+  # Step 2: Generate GitOps resources using go-templating
   - step: create-gitops-repo
     functionRef:
       name: function-go-templating
@@ -32,8 +45,12 @@ spec:
           {{- $appName := .observed.composite.resource.spec.name | default "whoami" }}
           {{- $namespace := .observed.composite.resource.metadata.namespace }}
           
-          {{/* For now, default to localhost - dns-config integration needs different approach */}}
+          {{/* Determine domain from dns-config or default to localhost */}}
           {{- $domain := printf "%s.localhost" $appName }}
+          {{- $zone := index .context "apiextensions.crossplane.io/environment" "zone" }}
+          {{- if $zone }}
+            {{- $domain = printf "%s.%s" $appName $zone }}
+          {{- end }}
           
           {{/* Generate the deployment manifest content */}}
           {{- $deploymentYaml := printf `---
@@ -288,7 +305,7 @@ spec:
             repository: "https://github.com/open-service-portal/deploy-{{ $appName }}"
             mode: "gitops"
   
-  # Step 2: Mark as ready when all resources are created
+  # Step 3: Mark as ready when all resources are created
   - step: auto-ready
     functionRef:
       name: function-auto-ready


### PR DESCRIPTION
Fixed the environment configuration loading in both compositions by using function-environment-configs as a separate pipeline step, which is the correct way to load EnvironmentConfigs in Composition v1 Pipeline mode.