### PR TITLE
fix: remove spaces from label values

### DIFF
--- a/composition-direct.yaml
+++ b/composition-direct.yaml
@@ -7,7 +7,7 @@ metadata:
   name: whoamiapp-direct
   labels:
     mode: direct
-    description: "Direct Kubernetes deployment"
+    description: direct-deployment
 spec:
   compositeTypeRef:
     apiVersion: demo.openportal.dev/v1alpha1

--- a/composition-gitops.yaml
+++ b/composition-gitops.yaml
@@ -7,7 +7,7 @@ metadata:
   name: whoamiapp-gitops
   labels:
     mode: gitops
-    description: "GitOps deployment via GitHub repository"
+    description: gitops-deployment
 spec:
   compositeTypeRef:
     apiVersion: demo.openportal.dev/v1alpha1


### PR DESCRIPTION
Kubernetes labels cannot contain spaces. Changed description labels to use hyphens instead.