### PR TITLE
feat: migrate XRD group from demo.openportal.dev to openportal.dev

### DIFF
--- a/composition-direct.yaml
+++ b/composition-direct.yaml
@@ -10,7 +10,7 @@ metadata:
     description: direct-deployment
 spec:
   compositeTypeRef:
-    apiVersion: demo.openportal.dev/v1alpha1
+    apiVersion: openportal.dev/v1alpha1
     kind: WhoAmIApp
   
   mode: Pipeline

--- a/composition-gitops.yaml
+++ b/composition-gitops.yaml
@@ -10,7 +10,7 @@ metadata:
     description: gitops-deployment
 spec:
   compositeTypeRef:
-    apiVersion: demo.openportal.dev/v1alpha1
+    apiVersion: openportal.dev/v1alpha1
     kind: WhoAmIApp
   
   mode: Pipeline

--- a/example/demo-direct.yaml
+++ b/example/demo-direct.yaml
@@ -1,6 +1,6 @@
 # Example: Deploy WhoAmIApp directly to Kubernetes
 # This uses the direct composition that creates resources immediately
-apiVersion: demo.openportal.dev/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: WhoAmIApp
 metadata:
   name: demo-direct

--- a/example/demo-gitops.yaml
+++ b/example/demo-gitops.yaml
@@ -1,7 +1,7 @@
 # Example: Deploy WhoAmIApp via GitOps
 # This uses the gitops composition that creates a GitHub repository
 # with deployment manifests for Flux to deploy
-apiVersion: demo.openportal.dev/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: WhoAmIApp
 metadata:
   name: demo-gitops

--- a/example/myapp.yaml
+++ b/example/myapp.yaml
@@ -2,7 +2,7 @@
 # Domain will be automatically determined:
 # - If dns-config exists: myapp.<zone>
 # - Otherwise: myapp.localhost
-apiVersion: demo.openportal.dev/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: WhoAmIApp
 metadata:
   name: myapp

--- a/xrd.yaml
+++ b/xrd.yaml
@@ -4,7 +4,7 @@
 apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
-  name: whoamiapps.demo.openportal.dev
+  name: whoamiapps.openportal.dev
   labels:
     terasky.backstage.io/generate-form: "true"
   annotations:
@@ -15,7 +15,7 @@ metadata:
     terasky.backstage.io/lifecycle: 'production'
 spec:
   scope: Namespaced  # Crossplane v2 - XRs can be created in any namespace
-  group: demo.openportal.dev
+  group: openportal.dev
   names:
     kind: WhoAmIApp
     plural: whoamiapps


### PR DESCRIPTION
## Summary
- Migrate XRD group from `demo.openportal.dev` to `openportal.dev` for consistency
- Remove "demo" subdomain from all API versions

## Changes
- Updated XRD name from `whoamiapps.demo.openportal.dev` to `whoamiapps.openportal.dev`
- Updated group from `demo.openportal.dev` to `openportal.dev`
- Updated all apiVersion references from `demo.openportal.dev/v1alpha1` to `openportal.dev/v1alpha1`

## Benefits
- Consistent domain naming across all templates
- Removes unnecessary "demo" subdomain
- Better reflects production readiness