### PR TITLE
fix: update compositions to use ClusterProviderConfig for managed API

### DIFF
--- a/composition-direct.yaml
+++ b/composition-direct.yaml
@@ -109,7 +109,7 @@ spec:
                             port: 80
                           initialDelaySeconds: 5
             providerConfigRef:
-              kind: ProviderConfig
+              kind: ClusterProviderConfig
               name: kubernetes-provider
           
           ---
@@ -144,7 +144,7 @@ spec:
                     protocol: TCP
                     name: http
             providerConfigRef:
-              kind: ProviderConfig
+              kind: ClusterProviderConfig
               name: kubernetes-provider
           
           ---
@@ -184,7 +184,7 @@ spec:
                             port:
                               number: 80
             providerConfigRef:
-              kind: ProviderConfig
+              kind: ClusterProviderConfig
               name: kubernetes-provider
   
   # Step 3: Mark as ready when all resources are created

--- a/composition-gitops.yaml
+++ b/composition-gitops.yaml
@@ -173,7 +173,7 @@ spec:
           
           ---
           # ConfigMap to store the deployment manifest
-          apiVersion: kubernetes.crossplane.io/v1alpha2
+          apiVersion: kubernetes.m.crossplane.io/v1alpha1
           kind: Object
           metadata:
             name: {{ $xrName }}-gitops-content
@@ -196,6 +196,7 @@ spec:
                   kustomization.yaml: {{ $kustomizationYaml | quote }}
                   README.md: {{ $readmeContent | quote }}
             providerConfigRef:
+              kind: ClusterProviderConfig
               name: kubernetes-provider
           
           ---


### PR DESCRIPTION
## Summary
Updates WhoAmI compositions to use ClusterProviderConfig for the kubernetes.m.crossplane.io managed API.

## Context
After portal-workspace PR#64, we now have proper support for the managed API through ClusterProviderConfig. This PR updates the WhoAmI templates to use this new configuration.

## Changes
1. **composition-direct.yaml**:
   - Changed all `providerConfigRef.kind` from `ProviderConfig` to `ClusterProviderConfig`
   - Affects deployment, service, and ingress Objects

2. **composition-gitops.yaml**:
   - Changed `providerConfigRef.kind` from `ProviderConfig` to `ClusterProviderConfig`
   - Updated API version to `kubernetes.m.crossplane.io/v1alpha1` for ConfigMap Object

## Dependencies
- Requires portal-workspace PR#64 (already merged)
- Requires setup-cluster.sh to be run to create the ClusterProviderConfig

## Testing
Tested locally with:
```bash
# Applied updated compositions
kubectl apply -f composition-direct.yaml
kubectl apply -f composition-gitops.yaml

# Verified WhoAmI apps deploy successfully
kubectl get whoamiapps -A
# NAMESPACE      NAME                  SYNCED   READY   COMPOSITION        AGE
# demo           demo-whoami-felix     True     True    whoamiapp-direct   5m
# mstingl-demo   whoami-mstingl-demo   True     True    whoamiapp-direct   5m

# Verified K8s resources are created
kubectl get deployment,service,ingress -n mstingl-demo
# All resources created successfully

# Tested app is accessible
curl http://mstingl-demo.localhost
# Returns WhoAmI response
```

## Impact
- No breaking changes for existing deployments
- New deployments will use the managed API for better namespace isolation
- Compatible with provider-kubernetes v1.0.0

🤖 Generated with [Claude Code](https://claude.ai/code)